### PR TITLE
fix: uploading a file from reservation_details.php will refresh the page

### DIFF
--- a/src/upload.php
+++ b/src/upload.php
@@ -27,6 +27,13 @@ if ($bookingData == null) {
 
 $bookingID = $bookingData["id"];
 
+// check file size ** final size TBD **
+
+if ($_FILES['file']['size'] > 500000) {
+   echo "This file is too large.";
+   exit();
+}
+
 // get event key using time slot key
 
 $eventData = $database->getEventBySlotKey($slotKey);

--- a/static/view_js/upload.js
+++ b/static/view_js/upload.js
@@ -25,5 +25,9 @@ function uploadFile(fileData, slotKey) {
     type: "POST"
   }).done(function (response) {
     alert(response);
+    var sitePath = location.pathname;
+    if (sitePath.search("/reservation_details.php") > 0) {
+      location.reload();
+    }
   });
 }

--- a/templates/views/reservation_details.twig
+++ b/templates/views/reservation_details.twig
@@ -1,4 +1,4 @@
-{% extends 'layout/layout.twig' %}
+{% extends 'layout/logged_in_layout.twig' %}
 
 {% block page_head %}
   <link rel="stylesheet" href="static/css/reservationDetailsStyle.css">
@@ -91,7 +91,7 @@
                 {% if user_file %}
                   File:
                   <span>
-                    <a href="./{{ user_file }}" download>
+                    <a href="./MyEventBoard/{{ user_file }}" download>
                       {{ user_file|slice(27) }}
                     </a>
                   </span>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
when uploading a file from reservation_details.php the page will reload so that the user
can see the file they uploaded is there.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes a usability issue
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual testing only.  (this won't affect file uploads from the register.php page).
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
