### PR TITLE
fix: reservation_details will only reload if a file was uploaded

### DIFF
--- a/static/view_js/upload.js
+++ b/static/view_js/upload.js
@@ -26,7 +26,7 @@ function uploadFile(fileData, slotKey) {
   }).done(function (response) {
     alert(response);
     var sitePath = location.pathname;
-    if (sitePath.search("/reservation_details.php") > 0) {
+    if (sitePath.search("/reservation_details.php") > 0 && response == 'Your file has been uploaded.') {
       location.reload();
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Page will only reload if a file was successfully uploaded
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes an unlisted issue of the page reloaded everytime a file was rejected
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual testing
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
